### PR TITLE
Fix ESM

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,4 +16,6 @@ export type ISectResults = {
 export type ISectOptions = {
 }
 
-export default function isect(segments: Array<Segment>, options: ISectOptions) : ISectResults;
+export function bush(segments: Array<Segment>, options: ISectOptions) : ISectResults;
+export function sweep(segments: Array<Segment>, options: ISectOptions) : ISectResults;
+export function brute(segments: Array<Segment>, options: ISectOptions) : ISectResults;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "isect",
   "version": "3.0.1",
   "main": "build/isect.js",
-  "module": "./index.js",
+  "module": "build/isect.module.js",
   "types": "./index.d.ts",
   "scripts": {
     "pretest": "rollup -c",


### PR DESCRIPTION
Fixes the type exports for the 3 exported functions and points the module import at the correct file. It can't point at `index.js` as `index.js` contains imports to files in `devDependencies`.